### PR TITLE
seed: fix casing of Windows headers

### DIFF
--- a/src/seed.c
+++ b/src/seed.c
@@ -3,8 +3,8 @@
 #ifndef ED25519_NO_SEED
 
 #ifdef _WIN32
-#include <Windows.h>
-#include <Wincrypt.h>
+#include <windows.h>
+#include <wincrypt.h>
 #else
 #include <stdio.h>
 #endif


### PR DESCRIPTION
It will allow Windows cross-builds on *nix systems.