### PR TITLE
add ed25519_get_pubkey()

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,14 @@ byte buffer, `private_key` must be a writable 64 byte buffer and `seed` must be
 a 32 byte buffer.
 
 ```c
+void ed25519_get_pubkey(unsigned char *public_key, const unsigned char *private_key);
+```
+
+Derives public key from the given private key. `public_key` must be 
+a writable 32 byte buffer, `private_key` must be a 64 byte buffer with 
+a valid private key.
+
+```c
 void ed25519_sign(unsigned char *signature,
                   const unsigned char *message, size_t message_len,
                   const unsigned char *public_key, const unsigned char *private_key);

--- a/src/ed25519.h
+++ b/src/ed25519.h
@@ -25,6 +25,7 @@ int ED25519_DECLSPEC ed25519_create_seed(unsigned char *seed);
 #endif
 
 void ED25519_DECLSPEC ed25519_create_keypair(unsigned char *public_key, unsigned char *private_key, const unsigned char *seed);
+void ED25519_DECLSPEC ed25519_get_pubkey(unsigned char *public_key, const unsigned char *private_key);
 void ED25519_DECLSPEC ed25519_sign(unsigned char *signature, const unsigned char *message, size_t message_len, const unsigned char *public_key, const unsigned char *private_key);
 int ED25519_DECLSPEC ed25519_verify(const unsigned char *signature, const unsigned char *message, size_t message_len, const unsigned char *public_key);
 void ED25519_DECLSPEC ed25519_add_scalar(unsigned char *public_key, unsigned char *private_key, const unsigned char *scalar);

--- a/src/sign.c
+++ b/src/sign.c
@@ -4,6 +4,14 @@
 #include "sc.h"
 
 
+void ed25519_get_pubkey(unsigned char *public_key, const unsigned char *private_key) {
+    ge_p3 A;
+
+    ge_scalarmult_base(&A, private_key);
+    ge_p3_tobytes(public_key, &A);
+}
+
+
 void ed25519_sign(unsigned char *signature, const unsigned char *message, size_t message_len, const unsigned char *public_key, const unsigned char *private_key) {
     sha512_context hash;
     unsigned char hram[64];


### PR DESCRIPTION
Referring to Issue https://github.com/orlp/ed25519/issues/1

It's short and small function to extract public key from the private key, making it much easier to sign by just supplying a private key.

It enables this library to be used to build tools compatible with [`signify`](http://www.tedunangst.com/flak/post/signify) and [`minisign`](https://github.com/jedisct1/minisign).
