### PR TITLE
Updated ed25519_sign() to match current SUPERCOP/libsodium implementations

### DIFF
--- a/src/ed25519.h
+++ b/src/ed25519.h
@@ -25,7 +25,7 @@ int ED25519_DECLSPEC ed25519_create_seed(unsigned char *seed);
 #endif
 
 void ED25519_DECLSPEC ed25519_create_keypair(unsigned char *public_key, unsigned char *private_key, const unsigned char *seed);
-void ED25519_DECLSPEC ed25519_sign(unsigned char *signature, const unsigned char *message, size_t message_len, const unsigned char *public_key, const unsigned char *private_key);
+void ED25519_DECLSPEC ed25519_sign(unsigned char *signature, const unsigned char *message, size_t message_len, const unsigned char *private_key);
 int ED25519_DECLSPEC ed25519_verify(const unsigned char *signature, const unsigned char *message, size_t message_len, const unsigned char *public_key);
 void ED25519_DECLSPEC ed25519_add_scalar(unsigned char *public_key, unsigned char *private_key, const unsigned char *scalar);
 void ED25519_DECLSPEC ed25519_key_exchange(unsigned char *shared_secret, const unsigned char *public_key, const unsigned char *private_key);

--- a/src/keypair.c
+++ b/src/keypair.c
@@ -1,3 +1,4 @@
+#include <string.h>
 #include "ed25519.h"
 #include "sha512.h"
 #include "ge.h"
@@ -13,4 +14,7 @@ void ed25519_create_keypair(unsigned char *public_key, unsigned char *private_ke
 
     ge_scalarmult_base(&A, private_key);
     ge_p3_tobytes(public_key, &A);
+
+    memmove(private_key, seed, 32);
+    memmove(private_key + 32, public_key, 32);
 }

--- a/src/sign.c
+++ b/src/sign.c
@@ -4,28 +4,37 @@
 #include "sc.h"
 
 
-void ed25519_sign(unsigned char *signature, const unsigned char *message, size_t message_len, const unsigned char *public_key, const unsigned char *private_key) {
+void ed25519_sign(unsigned char *signature, const unsigned char *message, size_t message_len, const unsigned char *private_key) {
     sha512_context hash;
     unsigned char hram[64];
-    unsigned char r[64];
+    unsigned char nonce[64];
+    unsigned char az[64];
     ge_p3 R;
 
+    sha512(private_key, 32, az);
+    az[0] &= 248;
+    az[31] &= 63;
+    az[31] |= 64;
 
     sha512_init(&hash);
-    sha512_update(&hash, private_key + 32, 32);
+    sha512_update(&hash, az + 32, 32);
     sha512_update(&hash, message, message_len);
-    sha512_final(&hash, r);
+    sha512_final(&hash, nonce);
 
-    sc_reduce(r);
-    ge_scalarmult_base(&R, r);
+    memmove(signature + 32, private_key + 32, 32);
+
+    sc_reduce(nonce);
+    ge_scalarmult_base(&R, nonce);
     ge_p3_tobytes(signature, &R);
 
     sha512_init(&hash);
-    sha512_update(&hash, signature, 32);
-    sha512_update(&hash, public_key, 32);
+    sha512_update(&hash, signature, 64);
     sha512_update(&hash, message, message_len);
     sha512_final(&hash, hram);
 
     sc_reduce(hram);
-    sc_muladd(signature + 32, hram, private_key, r);
+    sc_muladd(signature + 32, hram, az, nonce);
+
+    memset(az, 0, sizeof(az));
+    memset(nonce, 0, sizeof(nonce));
 }

--- a/src/sign.c
+++ b/src/sign.c
@@ -1,3 +1,4 @@
+#include <string.h>
 #include "ed25519.h"
 #include "sha512.h"
 #include "ge.h"


### PR DESCRIPTION
Following up on the issue left in the tracker earlier. I figure that code is better than an issue report. THis fixes the noted issue and now generates output that interoperates with libsodium (haven't tested against NaCL). It's worth noting that the public key is no longer required for the signing operation, so I removed it from the function prototype. This changes your interface, and I don't know how stable you were trying to keep the API, so do with this as you will.

I also added some memset() calls before function exit to zero out potentially sensitive transient data.