### PR TITLE
Fix warning

### DIFF
--- a/src/fe.c
+++ b/src/fe.c
@@ -820,16 +820,16 @@ void fe_mul121666(fe h, fe f) {
     carry6 = (h6 + (int64_t) (1<<25)) >> 26; h7 += carry6; h6 -= carry6 << 26;
     carry8 = (h8 + (int64_t) (1<<25)) >> 26; h9 += carry8; h8 -= carry8 << 26;
 
-    h[0] = h0;
-    h[1] = h1;
-    h[2] = h2;
-    h[3] = h3;
-    h[4] = h4;
-    h[5] = h5;
-    h[6] = h6;
-    h[7] = h7;
-    h[8] = h8;
-    h[9] = h9;
+    h[0] = (int32_t) h0;
+    h[1] = (int32_t) h1;
+    h[2] = (int32_t) h2;
+    h[3] = (int32_t) h3;
+    h[4] = (int32_t) h4;
+    h[5] = (int32_t) h5;
+    h[6] = (int32_t) h6;
+    h[7] = (int32_t) h7;
+    h[8] = (int32_t) h8;
+    h[9] = (int32_t) h9;
 }
 
 


### PR DESCRIPTION
```
fe.c(823): warning C4244: '=' : conversion from 'int64_t' to 'int32_t', possible loss of data
fe.c(824): warning C4244: '=' : conversion from 'int64_t' to 'int32_t', possible loss of data
fe.c(825): warning C4244: '=' : conversion from 'int64_t' to 'int32_t', possible loss of data
fe.c(826): warning C4244: '=' : conversion from 'int64_t' to 'int32_t', possible loss of data
fe.c(827): warning C4244: '=' : conversion from 'int64_t' to 'int32_t', possible loss of data
fe.c(828): warning C4244: '=' : conversion from 'int64_t' to 'int32_t', possible loss of data
fe.c(829): warning C4244: '=' : conversion from 'int64_t' to 'int32_t', possible loss of data
fe.c(830): warning C4244: '=' : conversion from 'int64_t' to 'int32_t', possible loss of data
fe.c(831): warning C4244: '=' : conversion from 'int64_t' to 'int32_t', possible loss of data
fe.c(832): warning C4244: '=' : conversion from 'int64_t' to 'int32_t', possible loss of data
```