### PR TITLE
MSVC build fixes

### DIFF
--- a/src/fixedint.h
+++ b/src/fixedint.h
@@ -4,7 +4,7 @@
     Not a compatible replacement for <stdint.h>, do not blindly use it as such.
 */
 
-#if ((defined(__STDC__) && __STDC__ && __STDC_VERSION__ >= 199901L) || (defined(__WATCOMC__) && (defined(_STDINT_H_INCLUDED) || __WATCOMC__ >= 1250)) || (defined(__GNUC__) && (defined(_STDINT_H) || defined(_STDINT_H_) || defined(__UINT_FAST64_TYPE__)) )) && !defined(FIXEDINT_H_INCLUDED)
+#if ((defined(__STDC__) && __STDC__ && __STDC_VERSION__ >= 199901L) || (defined(_MSC_VER) && _MSC_VER >= 1600) || (defined(__WATCOMC__) && (defined(_STDINT_H_INCLUDED) || __WATCOMC__ >= 1250)) || (defined(__GNUC__) && (defined(_STDINT_H) || defined(_STDINT_H_) || defined(__UINT_FAST64_TYPE__)) )) && !defined(FIXEDINT_H_INCLUDED)
     #include <stdint.h>
     #define FIXEDINT_H_INCLUDED
 
@@ -66,7 +66,11 @@
         typedef __int64 int64_t;
         typedef unsigned __int64 uint64_t;
 
+        #ifndef UINT64_C
         #define UINT64_C(v) v ##UI64
+        #endif
+        #ifndef INT64_C
         #define INT64_C(v) v ##I64
+        #endif
     #endif
 #endif


### PR DESCRIPTION
- Fix build error with MSVS 2008 (`stdint.h` missing)
- Avoid redefinition warning with MSVS 2015