### PR TITLE
seed: check return value of fread

### DIFF
--- a/src/seed.c
+++ b/src/seed.c
@@ -30,7 +30,11 @@ int ed25519_create_seed(unsigned char *seed) {
         return 1;
     }
 
-    fread(seed, 1, 32, f);
+    if (fread(seed, 1, 32, f) != 32) {
+        fclose(f);
+        return 1;
+    }
+
     fclose(f);
 #endif
 


### PR DESCRIPTION
The return value of fread should be checked to be sure we got the data
from urandom. Furthermore this fixes following gcc warning when
"-D_FORTIFY_SOURCE=2" is set:

seed.c: In function ‘ed25519_create_seed’:
seed.c:33:5: warning: ignoring return value of ‘fread’, declared with attribute warn_unused_result [-Wunused-result]
     fread(seed, 1, 32, f);
     ^~~~~~~~~~~~~~~~~~~~~

Signed-off-by: Richard Leitner <richard.leitner@skidata.com>