### PR TITLE
Updates to get easy for embedded systems

### DIFF
--- a/src/ed25519.h
+++ b/src/ed25519.h
@@ -24,12 +24,36 @@ extern "C" {
 int ED25519_DECLSPEC ed25519_create_seed(unsigned char *seed);
 #endif
 
+#include "sha512.h"
+#include "ge.h"
+typedef struct
+{
+    sha512_context hash_ct;
+    unsigned char r[64];
+} signature_context;
+typedef struct
+{
+    sha512_context hash_ct;
+    ge_p3 A;
+    int bool_number;
+    unsigned char *sig;
+} verify_context;
+
 void ED25519_DECLSPEC ed25519_create_keypair(unsigned char *public_key, unsigned char *private_key, const unsigned char *seed);
 void ED25519_DECLSPEC ed25519_sign(unsigned char *signature, const unsigned char *message, size_t message_len, const unsigned char *public_key, const unsigned char *private_key);
 int ED25519_DECLSPEC ed25519_verify(const unsigned char *signature, const unsigned char *message, size_t message_len, const unsigned char *public_key);
 void ED25519_DECLSPEC ed25519_add_scalar(unsigned char *public_key, unsigned char *private_key, const unsigned char *scalar);
 void ED25519_DECLSPEC ed25519_key_exchange(unsigned char *shared_secret, const unsigned char *public_key, const unsigned char *private_key);
 
+void ED25519_DECLSPEC ed25519_create_public_from_private(unsigned char *public_key, unsigned char *private_key);
+void ED25519_DECLSPEC ed25519_sign_init1(signature_context *sig_status, const unsigned char *private_key);
+void ED25519_DECLSPEC ed25519_sign_update1(signature_context *sig_status, const unsigned char *message_block, size_t block_len);
+void ED25519_DECLSPEC ed25519_sign_final1_init2(signature_context *sig_status, unsigned char *signature, const unsigned char *public_key);
+void ED25519_DECLSPEC ed25519_sign_update2(signature_context *sig_status, const unsigned char *message_block, size_t block_len);
+void ED25519_DECLSPEC ed25519_sign_final2(signature_context *sig_status, unsigned char *signature, const unsigned char *private_key);
+void ED25519_DECLSPEC ed25519_verify_init(verify_context *ver_status, const unsigned char *signature, const unsigned char *public_key);
+void ED25519_DECLSPEC ed25519_verify_update(verify_context *ver_status, const unsigned char *message_block, size_t block_len);
+int ED25519_DECLSPEC ed25519_verify_final(verify_context *ver_status);
 
 #ifdef __cplusplus
 }

--- a/src/keypair.c
+++ b/src/keypair.c
@@ -14,3 +14,15 @@ void ed25519_create_keypair(unsigned char *public_key, unsigned char *private_ke
     ge_scalarmult_base(&A, private_key);
     ge_p3_tobytes(public_key, &A);
 }
+
+void ed25519_create_public_from_private(unsigned char *public_key, unsigned char *private_key)
+{
+    ge_p3 A;
+
+    private_key[0] &= 248;
+    private_key[31] &= 63;
+    private_key[31] |= 64;
+
+    ge_scalarmult_base(&A, private_key);
+    ge_p3_tobytes(public_key, &A);
+}

--- a/src/sign.c
+++ b/src/sign.c
@@ -4,7 +4,8 @@
 #include "sc.h"
 
 
-void ed25519_sign(unsigned char *signature, const unsigned char *message, size_t message_len, const unsigned char *public_key, const unsigned char *private_key) {
+void ed25519_sign(unsigned char *signature, const unsigned char *message, size_t message_len, const unsigned char *public_key, const unsigned char *private_key)
+{
     sha512_context hash;
     unsigned char hram[64];
     unsigned char r[64];
@@ -28,4 +29,45 @@ void ed25519_sign(unsigned char *signature, const unsigned char *message, size_t
 
     sc_reduce(hram);
     sc_muladd(signature + 32, hram, private_key, r);
+}
+
+void ed25519_sign_init1(signature_context *sig_status, const unsigned char *private_key)
+{
+    sha512_init(&sig_status->hash_ct);
+    sha512_update(&sig_status->hash_ct, private_key + 32, 32);
+}
+
+void ed25519_sign_update1(signature_context *sig_status, const unsigned char *message_block, size_t block_len)
+{
+    sha512_update(&sig_status->hash_ct, message_block, block_len);
+}
+
+void ed25519_sign_final1_init2(signature_context *sig_status, unsigned char *signature, const unsigned char *public_key)
+{
+    ge_p3 R;
+
+    sha512_final(&sig_status->hash_ct, sig_status->r);
+
+    sc_reduce(sig_status->r);
+    ge_scalarmult_base(&R, sig_status->r);
+    ge_p3_tobytes(signature, &R);
+
+    sha512_init(&sig_status->hash_ct);
+    sha512_update(&sig_status->hash_ct, signature, 32);
+    sha512_update(&sig_status->hash_ct, public_key, 32);
+}
+
+void ed25519_sign_update2(signature_context *sig_status, const unsigned char *message_block, size_t block_len)
+{
+    sha512_update(&sig_status->hash_ct, message_block, block_len);
+}
+
+void ed25519_sign_final2(signature_context *sig_status, unsigned char *signature, const unsigned char *private_key)
+{
+    unsigned char hram[64];
+
+    sha512_final(&sig_status->hash_ct, hram);
+
+    sc_reduce(hram);
+    sc_muladd(signature + 32, hram, private_key, sig_status->r);
 }


### PR DESCRIPTION
- Breaking the signing and verifying process in parts for dealing with big messages with small RAM memory available.
- New function to derivate the public key from private key, without using a seed, allowing the user to make his/her own random private key generation and then get the respective public key.