### PR TITLE
Silence warnings converting between signed and unsigned types without an explicit cast

### DIFF
--- a/src/fe.c
+++ b/src/fe.c
@@ -295,16 +295,16 @@ void fe_copy(fe h, const fe f) {
 */
 
 void fe_frombytes(fe h, const unsigned char *s) {
-    int64_t h0 = load_4(s);
-    int64_t h1 = load_3(s + 4) << 6;
-    int64_t h2 = load_3(s + 7) << 5;
-    int64_t h3 = load_3(s + 10) << 3;
-    int64_t h4 = load_3(s + 13) << 2;
-    int64_t h5 = load_4(s + 16);
-    int64_t h6 = load_3(s + 20) << 7;
-    int64_t h7 = load_3(s + 23) << 5;
-    int64_t h8 = load_3(s + 26) << 4;
-    int64_t h9 = (load_3(s + 29) & 8388607) << 2;
+    int64_t h0 = (int64_t) load_4(s);
+    int64_t h1 = (int64_t) (load_3(s + 4) << 6);
+    int64_t h2 = (int64_t) (load_3(s + 7) << 5);
+    int64_t h3 = (int64_t) (load_3(s + 10) << 3);
+    int64_t h4 = (int64_t) (load_3(s + 13) << 2);
+    int64_t h5 = (int64_t) load_4(s + 16);
+    int64_t h6 = (int64_t) (load_3(s + 20) << 7);
+    int64_t h7 = (int64_t) (load_3(s + 23) << 5);
+    int64_t h8 = (int64_t) (load_3(s + 26) << 4);
+    int64_t h9 = (int64_t) ((load_3(s + 29) & 8388607) << 2);
     int64_t carry0;
     int64_t carry1;
     int64_t carry2;

--- a/src/ge.c
+++ b/src/ge.c
@@ -331,8 +331,8 @@ void ge_p3_tobytes(unsigned char *s, const ge_p3 *h) {
 
 
 static unsigned char equal(signed char b, signed char c) {
-    unsigned char ub = b;
-    unsigned char uc = c;
+    unsigned char ub = (unsigned char)b;
+    unsigned char uc = (unsigned char)c;
     unsigned char x = ub ^ uc; /* 0: yes; 1..255: no */
     uint64_t y = x; /* 0: yes; 1..255: no */
     y -= 1; /* large: yes; 0..254: no */
@@ -341,7 +341,7 @@ static unsigned char equal(signed char b, signed char c) {
 }
 
 static unsigned char negative(signed char b) {
-    uint64_t x = b; /* 18446744073709551361..18446744073709551615: yes; 0..255: no */
+    uint64_t x = (uint64_t) b; /* 18446744073709551361..18446744073709551615: yes; 0..255: no */
     x >>= 63; /* 1: yes; 0: no */
     return (unsigned char) x;
 }
@@ -356,18 +356,18 @@ static void cmov(ge_precomp *t, const ge_precomp *u, unsigned char b) {
 static void select(ge_precomp *t, int pos, signed char b) {
     ge_precomp minust;
     unsigned char bnegative = negative(b);
-    unsigned char babs = b - (((-bnegative) & b) << 1);
+    unsigned char babs = (unsigned char) (b - (((-bnegative) & b) << 1));
     fe_1(t->yplusx);
     fe_1(t->yminusx);
     fe_0(t->xy2d);
-    cmov(t, &base[pos][0], equal(babs, 1));
-    cmov(t, &base[pos][1], equal(babs, 2));
-    cmov(t, &base[pos][2], equal(babs, 3));
-    cmov(t, &base[pos][3], equal(babs, 4));
-    cmov(t, &base[pos][4], equal(babs, 5));
-    cmov(t, &base[pos][5], equal(babs, 6));
-    cmov(t, &base[pos][6], equal(babs, 7));
-    cmov(t, &base[pos][7], equal(babs, 8));
+    cmov(t, &base[pos][0], equal((signed char) babs, 1));
+    cmov(t, &base[pos][1], equal((signed char) babs, 2));
+    cmov(t, &base[pos][2], equal((signed char) babs, 3));
+    cmov(t, &base[pos][3], equal((signed char) babs, 4));
+    cmov(t, &base[pos][4], equal((signed char) babs, 5));
+    cmov(t, &base[pos][5], equal((signed char) babs, 6));
+    cmov(t, &base[pos][6], equal((signed char) babs, 7));
+    cmov(t, &base[pos][7], equal((signed char) babs, 8));
     fe_copy(minust.yplusx, t->yminusx);
     fe_copy(minust.yminusx, t->yplusx);
     fe_neg(minust.xy2d, t->xy2d);

--- a/src/sha512.c
+++ b/src/sha512.c
@@ -88,7 +88,7 @@ static const uint64_t K[80] = {
 #endif
 
 /* compress 1024-bits */
-static int sha512_compress(sha512_context *md, unsigned char *buf)
+static int sha512_compress(sha512_context *md, const unsigned char *buf)
 {
     uint64_t S[8], W[80], t0, t1;
     int i;
@@ -180,7 +180,7 @@ int sha512_update (sha512_context * md, const unsigned char *in, size_t inlen)
     }                                                                                       
     while (inlen > 0) {                                                                     
         if (md->curlen == 0 && inlen >= 128) {                           
-           if ((err = sha512_compress (md, (unsigned char *)in)) != 0) {               
+           if ((err = sha512_compress (md, in)) != 0) {
               return err;                                                                   
            }                                                                                
            md->length += 128 * 8;                                        


### PR DESCRIPTION
Hello,

Apologies for dropping this pull request on you out of the blue. An open-source library I depend on recently added ed25519 as a dependency, and that library has rather strict warning settings. This has resulted in 23 warnings when building my project. Since I try to eliminate all warnings, I would be very grateful if you would accept these changes.

Most of the warnings were caused by implicit conversions between signed and unsigned variables. I have done my best to not alter the behavior of the program, just to add explicit casts to silence the warnings.

Thank you for your time.