### PR TITLE
docs: fix simple typo, seperately -> separately

### DIFF
--- a/src/add_scalar.c
+++ b/src/add_scalar.c
@@ -45,7 +45,7 @@ void ed25519_add_scalar(unsigned char *public_key, unsigned char *private_key, c
         /* if we know the private key we don't need a point addition, which is faster */
         /* using a "timing attack" you could find out wether or not we know the private
            key, but this information seems rather useless - if this is important pass
-           public_key and private_key seperately in 2 function calls */
+           public_key and private_key separately in 2 function calls */
         if (private_key) {
             ge_scalarmult_base(&A, private_key);
         } else {


### PR DESCRIPTION
There is a small typo in src/add_scalar.c.

Should read `separately` rather than `seperately`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md